### PR TITLE
Reed fix issue #6

### DIFF
--- a/configs/dataset-small-skip-LinCrop6.yaml
+++ b/configs/dataset-small-skip-LinCrop6.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "THIN_REF_S2_P1_L3_2496_1563_2159",
+    ]
+    validation: [
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+    ]
+    test: [
+      "8bit_AS4_S2_P1_L6_2560_1750_2160",
+    ]
+  stack_downsampling:
+    type: 'None' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0
+#    number_of_images: 100
+    num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]
+  image_cropping:
+    type: 'linear' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
+    num_per_image: 6 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+  class_annotation_mapping:
+    class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
+#
+#  class_annotation_mapping:
+#    class_0: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+#}
+#  class_annotation_mapping:
+#    class_0_annotation_GVs: [100]
+#    class_1_annotation_GVs: [175]
+#    class_2_annotation_GVs: [250]

--- a/configs/dataset-small-skip-LinCrop6.yaml
+++ b/configs/dataset-small-skip-LinCrop6.yaml
@@ -15,7 +15,7 @@ dataset_config:
 #    number_of_images: 100
     num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
     num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
-  target_size: [512, 512]
+  target_size: [512, 512]  # width, height
   image_cropping:
     type: 'linear' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
     num_per_image: 6 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image

--- a/configs/dataset-small-skip-LinCrop7.yaml
+++ b/configs/dataset-small-skip-LinCrop7.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "THIN_REF_S2_P1_L3_2496_1563_2159",
+    ]
+    validation: [
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+    ]
+    test: [
+      "8bit_AS4_S2_P1_L6_2560_1750_2160",
+    ]
+  stack_downsampling:
+    type: 'None' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0
+#    number_of_images: 100
+    num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]  # width, height
+  image_cropping:
+    type: 'linear' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
+    num_per_image: 7 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+  class_annotation_mapping:
+    class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
+#
+#  class_annotation_mapping:
+#    class_0: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+#}
+#  class_annotation_mapping:
+#    class_0_annotation_GVs: [100]
+#    class_1_annotation_GVs: [175]
+#    class_2_annotation_GVs: [250]

--- a/configs/dataset-small-skip-allCrop.yaml
+++ b/configs/dataset-small-skip-allCrop.yaml
@@ -15,7 +15,7 @@ dataset_config:
 #    number_of_images: 100
     num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
     num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
-  target_size: [512, 512]
+  target_size: [512, 512]  # width, height
   image_cropping:
     type: 'all' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
     num_per_image: 6 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image

--- a/configs/dataset-small-skip-allCrop.yaml
+++ b/configs/dataset-small-skip-allCrop.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "THIN_REF_S2_P1_L3_2496_1563_2159",
+    ]
+    validation: [
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+    ]
+    test: [
+      "8bit_AS4_S2_P1_L6_2560_1750_2160",
+    ]
+  stack_downsampling:
+    type: 'None' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0
+#    number_of_images: 100
+    num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]
+  image_cropping:
+    type: 'all' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
+    num_per_image: 6 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+  class_annotation_mapping:
+    class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
+#
+#  class_annotation_mapping:
+#    class_0: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+#}
+#  class_annotation_mapping:
+#    class_0_annotation_GVs: [100]
+#    class_1_annotation_GVs: [175]
+#    class_2_annotation_GVs: [250]

--- a/configs/dataset-small-skip-crop.yaml
+++ b/configs/dataset-small-skip-crop.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "THIN_REF_S2_P1_L3_2496_1563_2159",
+    ]
+    validation: [
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+    ]
+    test: [
+      "8bit_AS4_S2_P1_L6_2560_1750_2160",
+    ]
+  stack_downsampling:
+    type: 'None' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0
+#    number_of_images: 100
+    num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]
+  image_cropping:
+    type: 'random' # 'None', 'random', 'all'
+    num_per_image: 3 # if `all` not selected, num of crops (of target size) per image
+  class_annotation_mapping:
+    class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
+#
+#  class_annotation_mapping:
+#    class_0: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+#}
+#  class_annotation_mapping:
+#    class_0_annotation_GVs: [100]
+#    class_1_annotation_GVs: [175]
+#    class_2_annotation_GVs: [250]

--- a/configs/dataset-small-skip-crop.yaml
+++ b/configs/dataset-small-skip-crop.yaml
@@ -17,8 +17,8 @@ dataset_config:
     num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
   target_size: [512, 512]
   image_cropping:
-    type: 'random' # 'None', 'random', 'all'
-    num_per_image: 3 # if `all` not selected, num of crops (of target size) per image
+    type: 'random' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
+    num_per_image: 3 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
   class_annotation_mapping:
     class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
 #

--- a/configs/dataset-xlarge_esrf16_v2_rand5crop.yaml
+++ b/configs/dataset-xlarge_esrf16_v2_rand5crop.yaml
@@ -1,0 +1,58 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "8bit_AS4_CNT_S1_P1_L2_2560_1750_2160",
+      "8bit_AS4_CNT_S1_P1_L3_2560_1750_2160",
+      "8bit_AS4_CNT_S1_P1_L4_2560_1750_2160",
+      "8bit_AS4_CNT_S1_P1_L5_2560_1750_2160",
+      "8bit_AS4_CNT_S1_P1_L6_2560_1750_2160",
+      "8bit_AS4_CNT_S2_P1_L5_2560_1800_2160",
+      "8bit_AS4_S1_P1_L0_2560_1800_2160",
+      "8bit_AS4_S1_P1_L1_2560_1800_2160",
+      "8bit_AS4_S1_P1_L2_2560_1800_2160",
+      "8bit_AS4_S1_P1_L3_2560_1800_2160",
+      "8bit_AS4_S1_P1_L4_2560_1800_2160",
+      "8bit_AS4_S1_P1_L5_2540_1720_2160",
+      "8bit_AS4_S1_P1_L6_2560_1800_2160",
+      "THIN_REF_S2_P1_L0_2508_1551_2159",
+      "THIN_REF_S2_P1_L1_2434_1547_2159",
+      "THIN_REF_S2_P1_L4_2433_1533_2159"
+    ]
+    validation: [
+      "8bit_AS4_CNT_S2_P1_L0_2560_1800_2160",
+      "8bit_AS4_CNT_S2_P1_L4_2560_1800_2160",
+      "8bit_AS4_CNT_S2_P1_L6_2560_1800_2160",
+      "THIN_REF_S2_P1_L2_2484_1524_2159",
+      "THIN_REF_S2_P1_L3_2496_1563_2159",
+    ]
+    test: [
+      "THIN_CNT_S2_P1_L0_2349_1578_2159",
+      "THIN_CNT_S2_P1_L2_2293_1581_2159",
+      "THIN_CNT_S2_P1_L3_2292_1566_2159",
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+      "THIN_CNT_S2_P1_L5_2316_1542_2159",
+      "8bit_AS4_S2_P1_L0_2560_1750_2160",
+      "8bit_AS4_S2_P1_L4_2560_1750_2160",
+      "8bit_AS4_S2_P1_L5_2560_1750_2160",
+      "8bit_AS4_S2_P1_L6_2560_1750_2160"
+    ]
+  stack_downsampling:
+    type: 'None' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0
+#    number_of_images: 100
+    num_skip_beg_slices: 5 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 5 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]  # width, height
+  image_cropping:
+    type: 'random' # 'None' (downscale img to target), 'linear' (def # crops), 'random' (def # crops), 'all' (all crops)
+    num_per_image: 5 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+  class_annotation_mapping:
+    class_0: ['0-degree_damage', '45-degree_damage', '90-degree_damage']
+#
+#  class_annotation_mapping:
+#    class_0: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+#}
+#  class_annotation_mapping:
+#    class_0_annotation_GVs: [100]
+#    class_1_annotation_GVs: [175]
+#    class_2_annotation_GVs: [250]

--- a/configs/train-small-skip-LinCrop6.yaml
+++ b/configs/train-small-skip-LinCrop6.yaml
@@ -1,6 +1,6 @@
 train_config:
   model_id_prefix: 'segmentation-model-small-skip-LinCrop6'
-  dataset_id: 'dataset-small-skip-crop'
+  dataset_id: 'dataset-small-skip-LinCrop6'
   segmentation_model:
     model_name: 'Unet'
     model_parameters:

--- a/configs/train-small-skip-LinCrop6.yaml
+++ b/configs/train-small-skip-LinCrop6.yaml
@@ -1,0 +1,15 @@
+train_config:
+  model_id_prefix: 'segmentation-model-small-skip-LinCrop6'
+  dataset_id: 'dataset-small-skip-crop'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16
+  epochs: 5
+  training_data_shuffle_seed: 1234
+  data_augmentation:
+    random_90-degree_rotations: True

--- a/configs/train-small-skip-LinCrop7.yaml
+++ b/configs/train-small-skip-LinCrop7.yaml
@@ -1,0 +1,15 @@
+train_config:
+  model_id_prefix: 'segmentation-model-small-skip-LinCrop7'
+  dataset_id: 'dataset-small-skip-LinCrop7'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16
+  epochs: 5
+  training_data_shuffle_seed: 1234
+  data_augmentation:
+    random_90-degree_rotations: True

--- a/configs/train-small-skip-allCrop.yaml
+++ b/configs/train-small-skip-allCrop.yaml
@@ -1,0 +1,15 @@
+train_config:
+  model_id_prefix: 'segmentation-model-small-skip-allCrop'
+  dataset_id: 'dataset-small-skip-allCrop'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16
+  epochs: 5
+  training_data_shuffle_seed: 1234
+  data_augmentation:
+    random_90-degree_rotations: True

--- a/configs/train-small-skip-crop.yaml
+++ b/configs/train-small-skip-crop.yaml
@@ -1,0 +1,15 @@
+train_config:
+  model_id_prefix: 'segmentation-model-small-skip-crop'
+  dataset_id: 'dataset-small-skip-crop'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16
+  epochs: 5
+  training_data_shuffle_seed: 1234
+  data_augmentation:
+    random_90-degree_rotations: True

--- a/configs/train-xlarge_esrf16_v2_rand5crop.yaml
+++ b/configs/train-xlarge_esrf16_v2_rand5crop.yaml
@@ -1,0 +1,15 @@
+train_config:
+  model_id_prefix: 'segmentation-model-xlarge_esrf16_v2_rand5crop'
+  dataset_id: 'dataset-xlarge_esrf16_v2_rand5crop'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16
+  epochs: 100
+  training_data_shuffle_seed: 1234
+  data_augmentation:
+    random_90-degree_rotations: True

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -155,7 +155,7 @@ def resize_and_crop(data_prep_local_dir, target_size, image_cropping_params):
                             (Path(data_prep_local_dir, 'resized', scan, 'annotations', scan_annotation_files[
                                 image_ind].name).as_posix()).replace('.', ('_crop' + str(counter_crop) + '.')))
                         if horiz_counter == (num_tiles_hor - 1):  # reached rhs of img, move back to lhs & down by trgt
-                            horiz_counter == 0
+                            horiz_counter = 0
                             vert_counter += 1
                             if vert_counter > (num_tiles_ver - 1):
                                 break  # regardless of num crops input, the bot rhs of img has been reach

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -132,8 +132,8 @@ def resize_and_crop(data_prep_local_dir, target_size, image_cropping_params):
                     assert image_cropping_params['num_per_image'] <= 36  # suits 4600 x 2048 img with 512 x 512 target
                     img = np.asarray(image)
                     mask = np.asarray(annotation)
-                    num_tiles_hor = np.ceil(img.shape[1] / target_size[0])
-                    num_tiles_ver = np.ceil(img.shape[0] / target_size[1])
+                    num_tiles_hor = np.int(np.ceil(img.shape[1] / target_size[0]))
+                    num_tiles_ver = np.int(np.ceil(img.shape[0] / target_size[1]))
                     horiz_counter = 0  # gets reset (cyclic)
                     vert_counter = 0  # does not get reset (not cyclic)
                     for counter_crop in range(image_cropping_params['num_per_image']):  # L to R, then move down by trgt
@@ -141,12 +141,10 @@ def resize_and_crop(data_prep_local_dir, target_size, image_cropping_params):
                             x_crop_lhs = horiz_counter * target_size[0]
                         elif horiz_counter == (num_tiles_hor - 1):
                             x_crop_lhs = img.shape[1] - target_size[0]
-
                         if vert_counter < (num_tiles_ver - 1):
                             y_crop_top = vert_counter * target_size[1]
                         elif vert_counter == (num_tiles_ver - 1):
                             y_crop_top = img.shape[0] - target_size[1]
-
                         image_crop = img[y_crop_top:y_crop_top+target_size[1], x_crop_lhs:x_crop_lhs+target_size[0]]
                         annotation_crop = mask[y_crop_top:y_crop_top+target_size[1], x_crop_lhs:x_crop_lhs+target_size[0]]
                         image_crop = Image.fromarray(image_crop)
@@ -168,8 +166,8 @@ def resize_and_crop(data_prep_local_dir, target_size, image_cropping_params):
                 elif image_cropping_params['type'] == 'all':  # do not train with pad, some overlap okay (still aug'd)
                     img = np.asarray(image)
                     mask = np.asarray(annotation)
-                    num_tiles_hor = np.ceil(img.shape[1] / target_size[0])
-                    num_tiles_ver = np.ceil(img.shape[0] / target_size[1])
+                    num_tiles_hor = np.int(np.ceil(img.shape[1] / target_size[0]))
+                    num_tiles_ver = np.int(np.ceil(img.shape[0] / target_size[1]))
                     counter_crop = 0
                     for vert_counter in range(num_tiles_ver):  # L to R, then move down by trgt
                         for horiz_counter in range(num_tiles_hor):


### PR DESCRIPTION
Addressed issue #6 (can be merged and closed upon review). Three major changes to `prepare_dataset.py`, which are `random` cropping for num>1, `linear` cropping, and `all` crops; there are also corresponding changes to dataset config file re cropping field, since `linear` is a new choice. See cropping examples below:
![rand3](https://user-images.githubusercontent.com/55461758/69487721-c1250480-0e2c-11ea-9262-32cac06807aa.PNG)
![Lin7](https://user-images.githubusercontent.com/55461758/69487726-cf732080-0e2c-11ea-9e45-df20d382858f.PNG)
![all](https://user-images.githubusercontent.com/55461758/69487727-d69a2e80-0e2c-11ea-83f2-2a25af843624.PNG)

