### PR TITLE
exactly match `folder_name` in exist check

### DIFF
--- a/gcp_utils.py
+++ b/gcp_utils.py
@@ -22,7 +22,7 @@ def copy_file_locally_if_missing(file_remote_path, local_file_path):
     os.system("gsutil cp -n '{}' '{}'".format(file_remote_path, local_file_path))
 
 
-def remote_folder_exists(remote_dest, folder_name):
+def remote_folder_exists(remote_dest, folder_name, sample_file_name=None):
     with Path('terraform.tfvars').open() as f:
         line = f.readline()
         while line:
@@ -34,6 +34,16 @@ def remote_folder_exists(remote_dest, folder_name):
     bucket_name = remote_dest.split('/')[2]
     bucket = storage_client.get_bucket(bucket_name)
 
+    if sample_file_name is not None:
+        folder_name = '/'.join([folder_name] + [sample_file_name])
+
     blobs = bucket.list_blobs(prefix='/'.join(remote_dest.split('/')[3:] + [folder_name]),
-                              max_results=1)
-    return len(list(blobs)) >= 1
+                              max_results=None)
+
+    folder_exists = False
+    for blob in blobs:
+        if blob.name.split('/')[1] == folder_name.split('/')[0]:
+            folder_exists = True
+            break
+
+    return folder_exists

--- a/gcp_utils.py
+++ b/gcp_utils.py
@@ -35,7 +35,7 @@ def remote_folder_exists(remote_dest, folder_name, sample_file_name=None):
     bucket = storage_client.get_bucket(bucket_name)
 
     if sample_file_name is not None:
-        folder_name = '/'.join([folder_name] + [sample_file_name])
+        folder_name = '/'.join([folder_name, sample_file_name])
 
     blobs = bucket.list_blobs(prefix='/'.join(remote_dest.split('/')[3:] + [folder_name]),
                               max_results=None)

--- a/ingest_raw_data.py
+++ b/ingest_raw_data.py
@@ -47,11 +47,13 @@ def process_zip(gcp_bucket, zipped_stack):
 
     stack_dir = Path(tmp_directory, stack_id)
 
-    if not is_annotation and remote_folder_exists(os.path.join(gcp_bucket, 'processed-data', stack_id), "images"):
+    if not is_annotation and remote_folder_exists(os.path.join(gcp_bucket, 'processed-data'),
+                                                  '/'.join([stack_id] + ["images"])):
 
         print("{} has already been processed! Skipping...".format(os.path.join(stack_id, "images")))
 
-    elif is_annotation and remote_folder_exists(os.path.join(gcp_bucket, 'processed-data', stack_id), "annotations"):
+    elif is_annotation and remote_folder_exists(os.path.join(gcp_bucket, 'processed-data'),
+                                                '/'.join([stack_id] + ["annotations"])):
 
         print("{} has already been processed! Skipping...".format(os.path.join(stack_id, "annotations")))
 
@@ -99,7 +101,7 @@ def process_zip(gcp_bucket, zipped_stack):
         with Path(tmp_directory, stack_id, metadata_file_name).open('w') as f:
             yaml.safe_dump(metadata, f)
 
-        os.system("gsutil -m cp -r '{}' '{}'".format(unzipped_dir.parent.as_posix(),
+        os.system("gsutil -m cp -n -r '{}' '{}'".format(unzipped_dir.parent.as_posix(),
                                                      os.path.join(gcp_bucket, 'processed-data/')))
 
         print('\n Ingest Raw Data Metadata:')

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -287,8 +287,8 @@ def split_prepared_data(data_prep_local_dir, prepared_dataset_local_dir, dataset
 
 def copy_dataset_to_remote_dest(prepared_dataset_location, prepared_dataset_remote_dest, dataset_id):
     print('Copying dataset {} to gcp bucket...'.format(dataset_id))
-    os.system("gsutil -m cp -r '{}' '{}'".format(prepared_dataset_location.as_posix(),
-                                                 os.path.join(prepared_dataset_remote_dest, dataset_id)))
+    os.system("gsutil -m cp -n -r '{}' '{}'".format(prepared_dataset_location.as_posix(),
+                                                    os.path.join(prepared_dataset_remote_dest, dataset_id)))
 
 
 def prepare_dataset(gcp_bucket, config_file):
@@ -331,7 +331,7 @@ def prepare_dataset(gcp_bucket, config_file):
         all_scans += scans
     all_scans = sorted(set(all_scans))
 
-    assert not remote_folder_exists(prepared_dataset_remote_dest, dataset_id)
+    assert not remote_folder_exists(prepared_dataset_remote_dest, dataset_id, sample_file_name='config.yaml')
 
     copy_processed_data_locally_if_missing(all_scans, processed_data_remote_source, processed_data_local_dir)
 


### PR DESCRIPTION
@Josh-Joseph , this works and was tested on `prepare-dataset` and `ingest_raw_data`. I also added `-n` (do not overwrite flag) as `cp -n -r` when copying to bucket as a safety valve (not needed but extra layer of caution). 

This is issue #53 