### PR TITLE
Issue 32 init pretrained weigths

### DIFF
--- a/configs/config_sandbox/tf_version_debug/dataset-small-3class_tfversion_debug.yaml
+++ b/configs/config_sandbox/tf_version_debug/dataset-small-3class_tfversion_debug.yaml
@@ -18,7 +18,7 @@ dataset_config:
   target_size: [512, 512]  # width, height
   image_cropping:
     type: 'class' # 'None' (downscale to target), 'linear' (def # crops), 'random' (def # crops), `class` (def # crops), 'all' (all crops)
-    num_per_image: None # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+    num_per_image: 1 # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
     num_pos_per_class: 1 # if `class` selected, then is num of random class-positive crops (of target sz) per img, >0
     num_neg_per_class: 1 # if `class` selected, then is num of random class-negative crops (of target sz) per img, >=0
     min_num_class_pos_px: # if `class` selected, then is min num of class-pos pixels required in given class-pos crop, >0

--- a/configs/config_sandbox/tf_version_debug/dataset-small-3class_tfversion_debug.yaml
+++ b/configs/config_sandbox/tf_version_debug/dataset-small-3class_tfversion_debug.yaml
@@ -1,0 +1,33 @@
+dataset_config:
+  dataset_split:
+    train: [
+      "THIN_REF_S2_P1_L3_2496_1563_2159"
+    ]
+    validation: [
+      "THIN_CNT_S2_P1_L4_2334_1578_2159",
+    ]
+    test: [
+      "8bit_AS4_S2_P1_L6_2560_1750_2160",
+    ]
+  stack_downsampling:
+    type: 'linear' # 'None', 'random', 'linear', 'from_start', 'from_end'
+#    frac: 1.0  # if 'random', 'linear', 'from_start', or 'from_end' selected; ignored if `None` selected
+    number_of_images: 100  # if 'random', 'linear', 'from_start', or 'from_end' selected; ignored if `None` selected
+    num_skip_beg_slices: 50 # trims n slices off of beginning of stack with N total slices. Slice n+1 becomes new Slice 1
+    num_skip_end_slices: 50 # trims m slices off of end of stack with N total slices. Slice N-(m+1) becomes new last slice
+  target_size: [512, 512]  # width, height
+  image_cropping:
+    type: 'class' # 'None' (downscale to target), 'linear' (def # crops), 'random' (def # crops), `class` (def # crops), 'all' (all crops)
+    num_per_image: None # if 'linear' (translation) or 'random' selected, then is num of crops (of target size) per image
+    num_pos_per_class: 1 # if `class` selected, then is num of random class-positive crops (of target sz) per img, >0
+    num_neg_per_class: 1 # if `class` selected, then is num of random class-negative crops (of target sz) per img, >=0
+    min_num_class_pos_px: # if `class` selected, then is min num of class-pos pixels required in given class-pos crop, >0
+#      class_0_pos_px: 10 # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+      class_0_pos_px: 5 # '0-degree_damage'
+      class_1_pos_px: 5 # '45-degree_damage'
+      class_2_pos_px: 5  # '90-degree_damage'
+  class_annotation_mapping:
+#    class_0_annotation_GVs: [100, 175, 250]  # '0-degree_damage', '45-degree_damage', '90-degree_damage'
+    class_0_annotation_GVs: [100]  # '0-degree_damage'
+    class_1_annotation_GVs: [175]  # '45-degree_damage'
+    class_2_annotation_GVs: [250]  # '90-degree_damage'

--- a/configs/config_sandbox/tf_version_debug/train-small-3class_tfversion_debug.yaml
+++ b/configs/config_sandbox/tf_version_debug/train-small-3class_tfversion_debug.yaml
@@ -1,0 +1,17 @@
+train_config:
+  model_id_prefix: 'segmentation-model-small-3class_tfversion_debug'
+  dataset_id: 'dataset-small-3class_tfversion_debug'
+  segmentation_model:
+    model_name: 'Unet'
+    model_parameters:
+      backbone_name: 'vgg16'
+      encoder_weights: Null   # Null (random initialization) or 'imagenet' (pre-training on ImageNet)
+  loss: 'cross_entropy'
+  optimizer: 'adam'
+  batch_size: 16    # p100
+  epochs: 10
+  training_data_shuffle_seed: 1234
+  validation_data_shuffle_seed: 12345
+  test_data_shuffle_seed: 123456
+  data_augmentation:
+    random_90-degree_rotations: False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-tensorflow-gpu
+tensorflow-gpu==2.1.0
 opencv-python
 scikit-image
 sklearn
@@ -8,7 +8,7 @@ Keras
 ipython
 segmentation-models
 pytz
-tensorboard
+tensorboard==2.1.0
 pillow
 pandas
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-tensorflow-gpu==2.1.0
+tensorflow-gpu
 opencv-python
 scikit-image
 sklearn
@@ -8,7 +8,7 @@ Keras
 ipython
 segmentation-models
 pytz
-tensorboard==2.1.0
+tensorboard
 pillow
 pandas
 google-cloud-storage

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -107,21 +107,16 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
 
         pretrained_info = {'pretrained_model_id': pretrained_model_id, 'pretrained_config': pretrained_model_config, 'pretrained_metadata': pretrained_model_metadata}
 
-        # confirm that the same model and backbone are used from pretrain and train
-        print(pretrained_model_config['segmentation_model']['model_name'], train_config['segmentation_model']['model_name'])
+        # confirm that the current model and pretrained model configurations are compatible
         assert pretrained_model_config['segmentation_model']['model_name'] == train_config['segmentation_model']['model_name']
-        print(pretrained_model_config['segmentation_model']['model_parameters']['backbone_name'], train_config['segmentation_model']['model_parameters']['backbone_name'])
         assert pretrained_model_config['segmentation_model']['model_parameters']['backbone_name'] == train_config['segmentation_model']['model_parameters']['backbone_name']
         # same loss function
-        print(pretrained_model_config['loss'], train_config['loss'])
         assert pretrained_model_config['loss'] == train_config['loss']
         # confirm that the number of classes in pretrain is the same as train
-        print(pretrained_model_metadata['num_classes'], len(train_generator.mask_filenames))
         assert pretrained_model_metadata['num_classes'] == len(train_generator.mask_filenames)
         # same target size
-        print(pretrained_model_metadata['dataset_config']['target_size'], dataset_config['target_size'])
         assert pretrained_model_metadata['dataset_config']['target_size'] == dataset_config['target_size']
-        input('done asserts')
+
     else:
         path_pretrained_model = None
         pretrained_info = None

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -202,7 +202,7 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
         'global_threshold_for_metrics': global_threshold,
         'random-module-global-seed': random_module_global_seed,
         'numpy_random_global_seed': numpy_random_global_seed,
-        'tf_random_global_seed': tf_random_global_seed
+        'tf_random_global_seed': tf_random_global_seed,
         'pre_trained_model_id': pre_trained_model_id,
         'pre_trained_model_config': pre_trained_model_config
     }

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -68,20 +68,20 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
     logs_dir.mkdir(parents=True)
 
     if pretrained_model_id is not None:
-        local_pre_trained_model_dir = Path(tmp_directory, 'pre_trained_models')
-        copy_folder_locally_if_missing(os.path.join(gcp_bucket, 'models', pretrained_model_id), local_pre_trained_model_dir)
-        path_pre_trained_model = Path(local_pre_trained_model_dir, pretrained_model_id, "model.hdf5").as_posix()
+        local_pretrained_model_dir = Path(tmp_directory, 'pretrained_models')
+        copy_folder_locally_if_missing(os.path.join(gcp_bucket, 'models', pretrained_model_id), local_pretrained_model_dir)
+        path_pretrained_model = Path(local_pretrained_model_dir, pretrained_model_id, "model.hdf5").as_posix()
 
-        with Path(local_pre_trained_model_dir, pretrained_model_id, 'config.yaml').open('r') as f:
-            pre_trained_model_config = yaml.safe_load(f)['train_config']
+        with Path(local_pretrained_model_dir, pretrained_model_id, 'config.yaml').open('r') as f:
+            pretrained_model_config = yaml.safe_load(f)['train_config']
 
-        with Path(local_pre_trained_model_dir, pretrained_model_id, 'metadata.yaml').open('r') as f:
-            pre_trained_model_metadata = yaml.safe_load(f)
+        with Path(local_pretrained_model_dir, pretrained_model_id, 'metadata.yaml').open('r') as f:
+            pretrained_model_metadata = yaml.safe_load(f)
 
-        pretrained_model_info = {'pretrained_id': pretrained_model_id, 'pretrained_config': pre_trained_model_config, 'pretrained_meta': pre_trained_model_metadata}
+        pretrained_info = {'pretrained_model_id': pretrained_model_id, 'pretrained_config': pretrained_model_config, 'pretrained_metadata': pretrained_model_metadata}
 
     else:
-        pretrained_model_info = None
+        pretrained_info = None
 
     with Path(local_dataset_dir, train_config['dataset_id'], 'config.yaml').open('r') as f:
         dataset_config = yaml.safe_load(f)['dataset_config']
@@ -116,7 +116,7 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
         len(train_generator.mask_filenames),
         train_config['loss'],
         train_config['optimizer'],
-        path_pre_trained_model)
+        path_pretrained_model)
 
     model_checkpoint_callback = ModelCheckpoint(Path(model_dir, 'model.hdf5').as_posix(),
                                                 monitor='loss', verbose=1, save_best_only=True)
@@ -209,7 +209,7 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
         'random-module-global-seed': random_module_global_seed,
         'numpy_random_global_seed': numpy_random_global_seed,
         'tf_random_global_seed': tf_random_global_seed,
-        'pretrained_model_info': pretrained_model_info
+        'pretrained_model_info': pretrained_info
     }
 
     with Path(model_dir, metadata_file_name).open('w') as f:

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -15,6 +15,11 @@ from gcp_utils import copy_folder_locally_if_missing
 from models import generate_compiled_segmentation_model
 from metrics_utils import global_threshold
 
+from numpy.random import seed
+seed(1)
+import tensorflow
+tensorflow.random.set_seed(2)
+
 
 metadata_file_name = 'metadata.yaml'
 tmp_directory = Path('./tmp')
@@ -61,6 +66,7 @@ def train(gcp_bucket, config_file, pre_trained_model_id):
 
     # copy the pretrained model to temp/models/pre_trained_models
     path_pre_trained_model = None
+    pre_trained_model_config = None
     if pre_trained_model_id is not None:
         local_pre_trained_model_dir = Path(tmp_directory, 'pre_trained_models')
         copy_folder_locally_if_missing(os.path.join(gcp_bucket, 'models', pre_trained_model_id), local_pre_trained_model_dir)

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -81,6 +81,7 @@ def train(gcp_bucket, config_file, random_module_global_seed, numpy_random_globa
         pretrained_info = {'pretrained_model_id': pretrained_model_id, 'pretrained_config': pretrained_model_config, 'pretrained_metadata': pretrained_model_metadata}
 
     else:
+        path_pretrained_model = None
         pretrained_info = None
 
     with Path(local_dataset_dir, train_config['dataset_id'], 'config.yaml').open('r') as f:


### PR DESCRIPTION
Resolving issue #32  - enable training starting from pretrained weights

Tested on tf2.1. Can be tested as e.g:

`python3 train_segmentation_model.py --gcp-bucket gs://necstlab-sandbox --config-file configs/config_sandbox/tf_version_debug//train-small-3class_tfversion_debug.yaml  --random-module-global-seed 1 --numpy-random-global-seed 1 --tf-random-global-seed 1 --pre-trained-model-id segmentation-model-small-3class_tfversion_debug_20201019T174848Z`

If no `--pre-trained-model-id` is given, it is initiated as none and random weights are given. 

The metadata of the pretrained model is also included: 

![image](https://user-images.githubusercontent.com/43469359/96909458-110cb100-146c-11eb-8c35-af6bae33791c.png)

 