### PR TITLE
Issue 75 upgrade tfversion

### DIFF
--- a/models.py
+++ b/models.py
@@ -160,10 +160,12 @@ class EvaluateModelForInputThreshold:
         all_results = optimizing_model.evaluate(self.dataset_generator,
                                                 steps=np.ceil(self.dataset_downsample_factor *
                                                               len(self.dataset_generator)).astype(int))
-        if hasattr(optimizing_model.loss, '__name__'):
-            metric_names = [optimizing_model.loss.__name__] + [m.name for m in optimizing_model.metrics]
-        elif hasattr(optimizing_model.loss, 'name'):
-            metric_names = [optimizing_model.loss.name] + [m.name for m in optimizing_model.metrics]
+        # if hasattr(optimizing_model.loss, '__name__'):
+        #    metric_names = [optimizing_model.loss.__name__] + [m.name for m in optimizing_model.metrics]
+        # elif hasattr(optimizing_model.loss, 'name'):
+        #    metric_names = [optimizing_model.loss.name] + [m.name for m in optimizing_model.metrics]
+
+        metric_names = [m.name for m in optimizing_model.metrics]
         dict_results = dict(zip(metric_names, all_results))
 
         optimizing_result = dict_results[str('class' + str(self.optimizing_class_id) + '_'

--- a/models.py
+++ b/models.py
@@ -160,10 +160,6 @@ class EvaluateModelForInputThreshold:
         all_results = optimizing_model.evaluate(self.dataset_generator,
                                                 steps=np.ceil(self.dataset_downsample_factor *
                                                               len(self.dataset_generator)).astype(int))
-        # if hasattr(optimizing_model.loss, '__name__'):
-        #    metric_names = [optimizing_model.loss.__name__] + [m.name for m in optimizing_model.metrics]
-        # elif hasattr(optimizing_model.loss, 'name'):
-        #    metric_names = [optimizing_model.loss.name] + [m.name for m in optimizing_model.metrics]
 
         metric_names = [m.name for m in optimizing_model.metrics]
         dict_results = dict(zip(metric_names, all_results))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-tensorflow-gpu
+tensorflow-gpu # use version >= 2.2
 opencv-python
 scikit-image
 sklearn

--- a/test_segmentation_model.py
+++ b/test_segmentation_model.py
@@ -66,7 +66,7 @@ def test(gcp_bucket, dataset_id, model_id, batch_size, trained_thresholds_id, ra
 
     test_generator = ImagesAndMasksGenerator(
         Path(local_dataset_dir, dataset_id, 'test').as_posix(),
-        rescale=1./255,
+        rescale=1. / 255,
         target_size=target_size,
         batch_size=batch_size,
         seed=None if 'test_data_shuffle_seed' not in train_config else train_config['test_data_shuffle_seed'])
@@ -95,11 +95,12 @@ def test(gcp_bucket, dataset_id, model_id, batch_size, trained_thresholds_id, ra
 
     results = compiled_model.evaluate(test_generator)
 
-    if hasattr(compiled_model.loss, '__name__'):
-        metric_names = [compiled_model.loss.__name__] + [m.name for m in compiled_model.metrics]
-    elif hasattr(compiled_model.loss, 'name'):
-        metric_names = [compiled_model.loss.name] + [m.name for m in compiled_model.metrics]
+    # if hasattr(compiled_model.loss, '__name__'):
+    #    metric_names = [compiled_model.loss.__name__] + [m.name for m in compiled_model.metrics]
+    # elif hasattr(compiled_model.loss, 'name'):
+    #    metric_names = [compiled_model.loss.name] + [m.name for m in compiled_model.metrics]
 
+    metric_names = [m.name for m in compiled_model.metrics]
     with Path(test_dir, str('metrics_' + test_datetime + '.csv')).open('w') as f:
         f.write(','.join(metric_names) + '\n')
         f.write(','.join(map(str, results)))

--- a/test_segmentation_model.py
+++ b/test_segmentation_model.py
@@ -95,11 +95,6 @@ def test(gcp_bucket, dataset_id, model_id, batch_size, trained_thresholds_id, ra
 
     results = compiled_model.evaluate(test_generator)
 
-    # if hasattr(compiled_model.loss, '__name__'):
-    #    metric_names = [compiled_model.loss.__name__] + [m.name for m in compiled_model.metrics]
-    # elif hasattr(compiled_model.loss, 'name'):
-    #    metric_names = [compiled_model.loss.name] + [m.name for m in compiled_model.metrics]
-
     metric_names = [m.name for m in compiled_model.metrics]
     with Path(test_dir, str('metrics_' + test_datetime + '.csv')).open('w') as f:
         f.write(','.join(metric_names) + '\n')

--- a/train_segmentation_model.py
+++ b/train_segmentation_model.py
@@ -127,7 +127,7 @@ def train(gcp_bucket, config_file, pre_trained_model_id):
     )
 
     # individual plots
-    metric_names = ['loss'] + [m.name for m in compiled_model.metrics]
+    metric_names = [m.name for m in compiled_model.metrics]
     for metric_name in metric_names:
         fig, ax = plt.subplots()
         for split in ['train', 'validate']:

--- a/train_segmentation_model_prediction_thresholds.py
+++ b/train_segmentation_model_prediction_thresholds.py
@@ -76,7 +76,7 @@ def train_segmentation_model_prediction_thresholds(gcp_bucket, dataset_directory
 
     train_threshold_dataset_generator = ImagesAndMasksGenerator(
         Path(local_dataset_dir, dataset_directory).as_posix(),
-        rescale=1./255,
+        rescale=1. / 255,
         target_size=target_size,
         batch_size=batch_size,
         shuffle=True,
@@ -95,12 +95,12 @@ def train_segmentation_model_prediction_thresholds(gcp_bucket, dataset_directory
         if not training_threshold_output.success:
             AssertionError("Training prediction thresholds has failed. See function minimization command line output.")
 
-        training_thresholds_output.update({str('class'+str(i)): {'x': float(training_threshold_output.x),
-                                                                 'success': training_threshold_output.success,
-                                                                 'status': training_threshold_output.status,
-                                                                 'message': training_threshold_output.message,
-                                                                 'nfev': training_threshold_output.nfev,
-                                                                 'fun': float(training_threshold_output.fun)}})
+        training_thresholds_output.update({str('class' + str(i)): {'x': float(training_threshold_output.x),
+                                                                   'success': training_threshold_output.success,
+                                                                   'status': training_threshold_output.status,
+                                                                   'message': training_threshold_output.message,
+                                                                   'nfev': training_threshold_output.nfev,
+                                                                   'fun': float(training_threshold_output.fun)}})
         trained_prediction_thresholds.update({str('class' + str(i)): float(training_threshold_output.x)})
 
     metadata = {


### PR DESCRIPTION
**Decided to separate the tf version upgrade from the ubunto and drivers upgrade.**

Upgraded the tensorflow version. The only issue with the metric names. Before, `loss` was added by hand, with tf2.3, there is no need to do that. 

### Verifications:

#### tf2.3 provides repeatable results? Yes 
![image](https://user-images.githubusercontent.com/43469359/98253524-20e6c380-1f49-11eb-85b7-69ffc60316b8.png)

#### tf 2.1 and tf 2.3 provide the same results? Very similar but not equal: 
![image](https://user-images.githubusercontent.com/43469359/98253629-45db3680-1f49-11eb-9b79-e385bc0ae90c.png)

#### TRAIN: 
**Fixed the metrics mosaic by removing loss from metric_names. Results don't match exactly because we don't have repeatability between 2.1 and 2.3.**
##### tf.2.1
![image](https://user-images.githubusercontent.com/43469359/98253751-71f6b780-1f49-11eb-8447-8d2638e95995.png)
##### tf.2.3
![image](https://user-images.githubusercontent.com/43469359/98253761-74f1a800-1f49-11eb-9899-a4d12e447226.png)

#### TRAIN_THRESHOLSD: 
`dict_results = dict(zip(metric_names, all_results))` in `models.py` was compiling two lists with different dimensions. meaning the selected `optimizing_result` was wrong in the end. Removed `loss` from `metric_names`

#### **tf2.3 without the modification**
**wrong! loss +  binary_crossentropy + binary_ce_metric (off by one)**
**{'loss': 0.0010814343113452196,** 
**'binary_ce_metric': 3.68487532154127e-11,** WRONG!!!! should all be the same, but since we are dict(zip(10 names, 9 metrics)), it ignores the last one, and the 3 first are binary cross entropy
'class0_f1_score': 0.29115191102027893, 
'class0_binary_accuracy_sm': 0.9995417594909668, 
**'binary_crossentropy': 0.0010814343113452196,**
'class0_precision': 0.33629000186920166, 
'class0_binary_cross_entropy': 0.9995417594909668, 
'class0_iou_score': 0.31209734082221985,  **- this is the optimal value. wrong here**
'class0_binary_accuracy_tfkeras': 0.18490245938301086}

#### **tf2.3 with the modification**
**right! loss + binary_ce_metric** 
{'class0_f1_score': 0.31209734082221985, 
'class0_precision': 0.29115191102027893, 
'class0_recall': 0.33629000186920166,
**'loss': 0.0010814343113452196,** 
'class0_binary_cross_entropy': 3.68487532154127e-11, 
'class0_binary_accuracy_tfkeras': 0.9995417594909668, 
**'binary_ce_metric': 0.0010814343113452196,** 
'class0_binary_accuracy_sm': 0.9995417594909668,
'class0_iou_score': 0.18490245938301086} - **this is the optimal value. ok here**

### TEST:
Same issue: removed `loss` from `metric_names `. Results match.

![image](https://user-images.githubusercontent.com/43469359/97506094-88e94880-1950-11eb-90ec-3e9286ae37b6.png)


 

 