### PR TITLE
Cf/fix ingest

### DIFF
--- a/gcp_utils.py
+++ b/gcp_utils.py
@@ -7,7 +7,7 @@ import segmentation_models
 
 
 def list_files(gcp_bucket_name, prefix):
-    gcp_key_file_location = next(Path('./keys').iterdir())
+    gcp_key_file_location = list(Path(r'./keys').glob(r'*.json'))[0]
     storage_client = storage.Client.from_service_account_json(gcp_key_file_location.as_posix())
     bucket_name = gcp_bucket_name
     bucket = storage_client.get_bucket(bucket_name)

--- a/ingest_raw_data.py
+++ b/ingest_raw_data.py
@@ -70,10 +70,13 @@ def process_zip(gcp_bucket, zipped_stack):
                 # remove any non-image files
                 os.remove(f.as_posix())
             else:
-                # convert all images to greyscale (some are already and some aren't)
+                # Old code to convert all images to greyscale (some are already and some aren't)
                 # Image.open(f).convert("L").save(f)
-                # This code was giving an error due to some compression setting of the images
-                # So it was replaced with this one:
+                # The commented code was giving an error due to some compression setting of the SOME images:
+                #     return encoder(mode, *args + extra)
+                #     TypeError: argument 5 should be a str, not PosixPath
+                # The error seems to be related to the image metadata or to a compression setting of the image.
+                # A workaround was to copy and rename the image and delete the old one..
                 shutil.copyfile(f, temp_file_name)
                 os.remove(f)
                 im1 = Image.open(temp_file_name).convert("L").save(temp_file_name)


### PR DESCRIPTION
Ingest is now working. 3 Things were modified: 
- hidden file in the keys folder + the way it the code was defined to get the keys, created an error. Now it gets the json file in the keys folder, not just any file. 
- When converting the images to greyscale and saving them with the same name, there was an error due to some compression setting/metadata of the images. Created a workaround: copy the image, convert it and save it, delete the original image, and change the name of the new to the original name
- The name convention of the raw data changed a little, so I needed to update the way it was dividing the name (to get images and masks)  